### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,35 +6,35 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-FlowMeter	 KEYWORD1
-FlowSensorProperties  KEYWORD1
-FlowSensorCalibration KEYWORD1
+FlowMeter	KEYWORD1
+FlowSensorProperties	KEYWORD1
+FlowSensorCalibration	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-getPin			        KEYWORD2
+getPin	KEYWORD2
 getCurrentFlowrate	KEYWORD2
-getCurrentFrequency KEYWORD2
-getCurrentVolume	  KEYWORD2
-getCurrentDuration  KEYWORD2
-getCurrentError     KEYWORD2
+getCurrentFrequency	KEYWORD2
+getCurrentVolume	KEYWORD2
+getCurrentDuration	KEYWORD2
+getCurrentError	KEYWORD2
 
-getTotalVolume	 	  KEYWORD2
-getTotalDuration	  KEYWORD2
-getTotalFlowrate	  KEYWORD2
-getTotalError       KEYWORD2
+getTotalVolume	KEYWORD2
+getTotalDuration	KEYWORD2
+getTotalFlowrate	KEYWORD2
+getTotalError	KEYWORD2
 
-tick	 		KEYWORD2
-count	 		KEYWORD2
-reset	 		KEYWORD2
+tick	KEYWORD2
+count	KEYWORD2
+reset	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
 #######################################
 
-FS400A    KEYWORD2
+FS400A	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords